### PR TITLE
Example Update Code Fix

### DIFF
--- a/upper-docs/upper.io/v3/content/examples/index.md.tpl
+++ b/upper-docs/upper.io/v3/content/examples/index.md.tpl
@@ -397,7 +397,7 @@ You can update all rows on the result set with the `Update()` method.
 var account Account
 res = col.Find("id", 5) // WHERE id = 5
 
-err = col.One(account)
+err = res.One(account)
 ...
 
 account.Name = "New name"


### PR DESCRIPTION
- Minor correction to the Update example code. Update example was incorrectly set to `col.One(account)` while other examples are `res.One(account)`