### PR TITLE
fixed a typo at line 124

### DIFF
--- a/upper-docs/upper.io/v3/content/postgresql/index.md
+++ b/upper-docs/upper.io/v3/content/postgresql/index.md
@@ -121,7 +121,7 @@ import (
 
 var settings = postgresql.ConnectionURL{
   Database: `upperio_tests`,
-  Host:     `localhost,`
+  Host:     `localhost`,
   User:     `upperio`,
   Password: `upperio`,
 }


### PR DESCRIPTION
fixed a typo at 124 in upper-docs/upper.io/v3/content/postgresql/index.md
