### PR TITLE
Fix typo in mssql server example

### DIFF
--- a/upper-docs/upper.io/v3/content/mssql/index.md
+++ b/upper-docs/upper.io/v3/content/mssql/index.md
@@ -71,7 +71,7 @@ Then, you can use the `mssql.Open()` method to create a session:
 
 ```go
 var settings = mssql.ConnectionURL{
-  Host:       "localhost",          // PostgreSQL server IP or name.
+  Host:       "localhost",          // MSSQL server IP or name.
   Database:   "peanuts",            // Database name.
   User:       "cbrown",             // Optional user name.
   Password:   "snoopy",             // Optional user password.


### PR DESCRIPTION
I was walking through the mssql examples today and noticed the comment was incorrect - small fix, but figured I'd submit a PR while I was thinking about it.