### PR TITLE
Fixing links to doc repo on contribute page

### DIFF
--- a/upper-docs/upper.io/v2/content/contribute/index.md
+++ b/upper-docs/upper.io/v2/content/contribute/index.md
@@ -30,7 +30,7 @@ into the main repository.
 
 [1]: https://github.com/upper/db
 [2]: https://github.com/upper/db/issues
-[3]: https://github.com/upper/docs
-[4]: https://github.com/upper/docs/issues
+[3]: https://github.com/upper/upper.io/
+[4]: https://github.com/upper/upper.io/issues
 [5]: https://help.github.com/articles/fork-a-repo
 [6]: https://help.github.com/articles/fork-a-repo#pull-requests

--- a/upper-docs/upper.io/v3/content/contribute/index.md
+++ b/upper-docs/upper.io/v3/content/contribute/index.md
@@ -30,7 +30,7 @@ into the main repository.
 
 [1]: https://github.com/upper/db
 [2]: https://github.com/upper/db/issues
-[3]: https://github.com/upper/docs
-[4]: https://github.com/upper/docs/issues
+[3]: https://github.com/upper/upper.io/
+[4]: https://github.com/upper/upper.io/issues
 [5]: https://help.github.com/articles/fork-a-repo
 [6]: https://help.github.com/articles/fork-a-repo#pull-requests


### PR DESCRIPTION
Links under **Improving the documentation** on the contribute page lead to 404  
https://upper.io/db.v3/contribute