### PR TITLE
highlight /examples in navbar

### DIFF
--- a/upper-docs/upper.io/v3/templates/index.tpl
+++ b/upper-docs/upper.io/v3/templates/index.tpl
@@ -67,6 +67,7 @@
           <span class="nav__trigger--adapters" id="adapters-menu-trigger">upper.io</span>
           <ul id="adapters-menu">
             <li><a href="//tour.upper.io">Tour</a></li>
+	    <li><a href="/db.v3/examples">Examples</a></li>
             <li><a href="/db.v3/adapters">Adapters</a></li>
             <li><a href="//godoc.org/upper.io/db.v3">Reference</a></li>
           </ul>


### PR DESCRIPTION
The /examples page is tremendously helpful in learning how to use upper! Let's promote this to the main menu to make it easier to navigate to.